### PR TITLE
Prevent crash when unsuccessfully parsing a number

### DIFF
--- a/PulsarPackCreator/Cups.cs
+++ b/PulsarPackCreator/Cups.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -204,7 +204,8 @@ namespace PulsarPackCreator
                 box.Text = "1";
                 return;
             }
-            UInt16 newCount = UInt16.Parse(box.Text);
+            if (!UInt16.TryParse(box.Text, out UInt16 newCount))
+                return;
             if (newCount > 1000)
             {
                 MsgWindow.Show("The maximum number of cups is 1000.");
@@ -224,7 +225,8 @@ namespace PulsarPackCreator
             if (!e.Handled)
             {
                 TextBox box = sender as TextBox;
-                int dest = int.Parse(box.Text + e.Text);
+                if (!int.TryParse(box.Text + e.Text, out int dest))
+                    return;
                 if (dest > ctsCupCount) e.Handled = true;
             }
         }
@@ -235,7 +237,8 @@ namespace PulsarPackCreator
             {
                 return;
             }
-            short dest = short.Parse(box.Text);
+            if (!short.TryParse(box.Text, out short dest))
+                return;
             UpdateCurCup((short)(dest - 1 - curCup));        
         }
 

--- a/PulsarPackCreator/File.cs
+++ b/PulsarPackCreator/File.cs
@@ -1,4 +1,4 @@
-﻿using Pulsar_Pack_Creator;
+using Pulsar_Pack_Creator;
 using System;
 using System.Diagnostics;
 using System.Drawing;
@@ -636,25 +636,28 @@ namespace PulsarPackCreator
                     if (curLine.Contains("?"))
                     {
                         string[] split = curLine.Split("?");
-                        UInt32 idx = UInt32.Parse(split[0], NumberStyles.HexNumber);
-                        if (split.Length > 1 && split[1] != "") cups[(int)idx].iconName = split[1];
+                        if (UInt32.TryParse(split[0], NumberStyles.HexNumber, null, out UInt32 idx))
+                        {
+                            if (split.Length > 1 && split[1] != "") cups[(int)idx].iconName = split[1];
+                        }
                     }
                     else
                     {
                         string[] split = curLine.Split("=");
-                        UInt32 id = UInt32.Parse(split[0], NumberStyles.HexNumber);
-
-                        int cupIdx = (int)id / 4;
-                        if (cupIdx < ctsCupCount)
+                        if (UInt32.TryParse(split[0], NumberStyles.HexNumber, null, out UInt32 id))
                         {
-                            int trackIdx = (int)id % 4;
-                            string[] names = split[1].Split("|");
-                            if (names.Length > 0)
+                            int cupIdx = (int)id / 4;
+                            if (cupIdx < ctsCupCount)
                             {
-                                cups[cupIdx].fileNames[trackIdx] = names[0];
-                                for (int i = 1; i < names.Length; i++)
+                                int trackIdx = (int)id % 4;
+                                string[] names = split[1].Split("|");
+                                if (names.Length > 0)
                                 {
-                                    cups[cupIdx].expertFileNames[trackIdx, i - 1] = names[i];
+                                    cups[cupIdx].fileNames[trackIdx] = names[0];
+                                    for (int i = 1; i < names.Length; i++)
+                                    {
+                                        cups[cupIdx].expertFileNames[trackIdx, i - 1] = names[i];
+                                    }
                                 }
                             }
                         }

--- a/PulsarPackCreator/Parameters.cs
+++ b/PulsarPackCreator/Parameters.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Windows;
 using System.Windows.Controls;
 
@@ -24,10 +24,6 @@ namespace PulsarPackCreator
             public int trackBlocking = 0;
             public string modFolderName;
         };
-        private void OnOptionsClick(object sender, RoutedEventArgs e)
-        {
-
-        }
         private void OnDateChange(object sender, SelectionChangedEventArgs e)
         {
             DatePicker datePicker = sender as DatePicker;
@@ -45,7 +41,7 @@ namespace PulsarPackCreator
             TextBox box = sender as TextBox;
             if (box.Text == "") return;
 
-            parameters.wiimmfiRegion = int.Parse(box.Text);
+            int.TryParse(box.Text, out parameters.wiimmfiRegion);
         }
 
         private void OnModFolderChange(object sender, TextChangedEventArgs e)
@@ -116,9 +112,9 @@ namespace PulsarPackCreator
             }
             if (CC100Box != null && CC150Box != null && CC100Box.Text != "" && CC150Box.Text != "")
             {
-                int Prob100 = int.Parse(CC100Box.Text);
+                if(!int.TryParse(CC100Box.Text, out int Prob100)) return;
                 if (Prob100 == 100) CC150Box.Text = "0";
-                int Prob150 = int.Parse(CC150Box.Text);
+                if (!int.TryParse(CC150Box.Text, out int Prob150)) return;
                 if (Prob100 + Prob150 > 100)
                 {
                     MsgWindow.Show("The sum of all probabilities should not exceed 100");
@@ -141,9 +137,9 @@ namespace PulsarPackCreator
             }
             if (CC100Box != null && CC150Box != null && CC100Box.Text != "" && CC150Box.Text != "")
             {
-                int Prob150 = int.Parse(CC150Box.Text);
+                if (!int.TryParse(CC150Box.Text, out int Prob150)) return;
                 if (Prob150 == 100) CC100Box.Text = "0";
-                int Prob100 = int.Parse(CC100Box.Text);
+                if (!int.TryParse(CC100Box.Text, out int Prob100)) return;
                 if (Prob100 + Prob150 > 100)
                 {
                     MsgWindow.Show("The sum of all info.probabilities should not exceed 100");


### PR DESCRIPTION
Currently, Pulsar crashes when it is unable to correctly parse a number. This pull request fixes that problem by using `TryParse` instead of `Parse`.